### PR TITLE
fix decoding month from literal

### DIFF
--- a/M41T62.cpp
+++ b/M41T62.cpp
@@ -134,7 +134,7 @@ DateTime::DateTime (const char* date, const char* time) {
     yOff = conv2d(date + 9);
     // Jan Feb Mar Apr May Jun Jul Aug Sep Oct Nov Dec 
     switch (date[0]) {
-        case 'J': m = date[1] == 'a' ? 1 : m = date[2] == 'n' ? 6 : 7; break;
+        case 'J': m = date[1] == 'a' ? 1 : date[2] == 'n' ? 6 : 7; break;
         case 'F': m = 2; break;
         case 'A': m = date[2] == 'r' ? 4 : 8; break;
         case 'M': m = date[2] == 'r' ? 3 : 5; break;


### PR DESCRIPTION
This is just to clear a warning, most of the time compiler fix itself the issue.